### PR TITLE
Started adding arrow key bindings

### DIFF
--- a/jquery.drop-down.coffee
+++ b/jquery.drop-down.coffee
@@ -98,16 +98,20 @@
 
     #
 #    $.fn.drawerExists        = -> $(this).next().length # Add filter for next
-    $.fn.drawerExists        = -> $(this).nextAll().filter($drawer).length # Add filter for next
+    $.fn.drawerExists        = -> $(this).nextAll().filter($drawer).length
 
 #    $.fn.drawerOpened        = -> $(this).parent().hasClass(toggleClass) # Add filter for parent
-    $.fn.drawerOpened        = -> $(this).closest($listItem).hasClass(toggleClass) # Add filter for parent
+    $.fn.drawerOpened        = -> $(this).closest($listItem).hasClass(toggleClass)
+
     $.fn.firstChild          = -> $(this).parent().is($firstListItem) # Add filter for parent
 
 #    $.fn.lastChild           = -> $(this).parent().is($lastListItem) # Add filter for parent
-    $.fn.lastChild           = -> $(this).closest($li).is($lastListItem)
+#    $.fn.lastChild           = -> $(this).closest($li).is($lastListItem)
+    $.fn.lastChild           = -> $(this).closest($listItem).is($lastListItem)
 
-    $.fn.lastItem            = -> $(this).parent().is($veryLastListItem) # Add filter for parent
+#    $.fn.lastItem            = -> $(this).parent().is($veryLastListItem) # Add filter for parent
+#    $.fn.lastItem            = -> $(this).closest($li).is($veryLastListItem)
+    $.fn.lastItem            = -> $(this).closest($listItem).is($veryLastListItem) # I don't think this is working correctly.
 
     # Click actions
     $.fn.toggleDrawer        = -> $(this).click()
@@ -115,13 +119,13 @@
     $.fn.closeParentDrawer   = -> $(this).closest($drawer).prevAll().filter($a).click()
 
     # Focus actions
-    $.fn.focusNextRootDrawer = -> $(this).closest($rootListItem).nextAll().filter($listItem).find($a).first().focus() # Add filter for next
-#    $.fn.focusNextDrawer     = -> $(this).closest($toggledListItem).nextAll().filter($listItem).first().find($a).first().focus()
+    $.fn.focusNextRootDrawer = -> $(this).closest($rootListItem).nextAll().filter($listItem).find($a).first().focus()
+    $.fn.focusNextDrawer     = -> $(this).closest($toggledListItem).nextAll().filter($listItem).first().find($a).first().focus() # Focuses the next drawer from inside a list.
     $.fn.focusParentDrawer   = -> $(this).closest($drawer).prevAll().filter($a).first().focus()
     $.fn.focusNextItem       = -> $(this).closest($listItem).nextAll().filter($listItem).first().find($a).first().focus()
     $.fn.focusPreviousItem   = -> $(this).closest($listItem).prevAll().filter($listItem).first().find($a).first().focus()
     $.fn.focusDrawerItem     = -> $(this).nextAll().filter($drawer).first().find($listItem).first().find($a).first().focus()
-    $.fn.focusDrawerItemUp   = -> $(this).closest($listItem).prevAll().filter($toggledListItem).first().find($listItem).last().find($a).first().focus() # This name sucks
+    $.fn.focusDrawerItemUp   = -> $(this).closest($listItem).prevAll().filter($toggledListItem).first().find($listItem).last().find($a).first().focus() # This variable name kinda sucks
 
     # Bind arrow keys
     $a.keydown (event) ->
@@ -147,8 +151,7 @@
           if $this.closest($listItem).prevAll().filter($listItem).first().hasClass(toggleClass) # These need to be in logic functions
             $this.focusDrawerItemUp()
 
-          #if when there's a previous drawer open, focus the last item in that drawer
-            #log('yes')
+          # If there's a previous drawer open, focus the last item in that drawer
 
       # Right
       if event.keyCode is 39
@@ -160,7 +163,7 @@
             $this.toggleDrawer()
         else
           if $this.lastChild()
-            if $this.lastItem() # you're not working, i dont' think
+            if $this.lastItem() # I don't think this is working correctly.
               $this.closeRootDrawer()
               $this.focusNextRootDrawer()
             else
@@ -172,10 +175,10 @@
       if event.keyCode is 40
         event.preventDefault()
         if $this.lastChild()
-          if $this.has($veryLastListItem) # not sure what logic is best
-            $this.focusDrawerItem()
-          else
-            $this.focusNextDrawer()
+          $this.focusNextDrawer()
+#          if $this.has($veryLastListItem) # I'm not sure if this is reliable logic for finding the last list?
+#            $this.focusDrawerItem()
+#          else
         else
           if $this.drawerOpened()
             $this.focusDrawerItem()

--- a/jquery.drop-down.coffee
+++ b/jquery.drop-down.coffee
@@ -18,11 +18,23 @@
     $a  = $this.find('a')
 
     #
-    $button   = $ul.siblings($a) # Buttons are anchors that sister an unordered-list
-    $parent   = $a.closest($li)  # Parents are list-items that parent anchors
-    $drawer   = $a.siblings($ul) # Drawers are unordered-lists sister anchors
-    $link     = $a.not($button)  # Links are anchors that are not buttons
-    $listItem = $li.has($a)      # List-items contain anchors
+    $button           = $ul.siblings($a)               # Buttons are anchors that sister an unordered-list
+    $parent           = $button.parent()               # Parents are list-items that parent buttons
+    $drawer           = $button.siblings($ul)          # Drawers are unordered-lists sister buttons
+    $link             = $a.not($button)                # Links are anchors that are not buttons
+    $listItem         = $li.has($a)
+    $rootListItem     = $ul.first().find($listItem)    # Root list-items are the first set of list-items in a menu
+    $firstListItem    = $listItem.find(':first-child') # First list-items are the first list-items in a list
+    $lastListItem     = $listItem.find(':last-child')  # Last list-items are the last list-items in a list
+    $nestedList       = $listItem.find($ul)            # Nested lists are unordered-lists that are in a list-item
+    $veryLastListItem = $()                            # Very last list-items are the very last list-tems in a nested list
+    $toggledListItem  = $()
+
+    #
+    $this.find($nestedList).not($nestedList.find($li).find($ul)).each ->
+      $nestedListItem = $(this).find($li)
+      if $nestedListItem.length
+        $veryLastListItem = $veryLastListItem.add($nestedListItem.last())
 
     #
     $button.click (event) ->
@@ -33,15 +45,18 @@
       $cParent         = $cButton.parent()
       $cUncle          = $cParent.siblings()
       $cDrawer         = $cButton.siblings($ul)
-      $cDrawerListItem = $cDrawer.find($li)     # These variable names kinda suck
+      $cDrawerListItem = $cDrawer.find($li) # These variable names kinda suck
       $cNestedDrawer   = $cDrawer.find($drawer) # These variable names kinda suck
+      $cRootListItem   = $cButton.closest($rootListItem)
 
       #
       if $cParent.hasClass(toggleClass)
         $cParent.removeClass(toggleClass)
         $cDrawer.css('height', '')
+        $toggledListItem = $toggledListItem.not($cParent) # Update toggled list-items for filtering when using arrow keys
       else
         $cParent.addClass(toggleClass)
+        $toggledListItem = $toggledListItem.add($cParent) # Update toggled list-items for filtering when using arrow keys
 
       # Reset children
       if $cDrawerListItem.hasClass(toggleClass)
@@ -80,6 +95,92 @@
     $(document).on 'click focusin', (event) ->
       if not $(event.target).closest($button.parent()).length
         closeMenu()
+
+    #
+#    $.fn.drawerExists        = -> $(this).next().length # Add filter for next
+    $.fn.drawerExists        = -> $(this).nextAll().filter($drawer).length # Add filter for next
+
+#    $.fn.drawerOpened        = -> $(this).parent().hasClass(toggleClass) # Add filter for parent
+    $.fn.drawerOpened        = -> $(this).closest($listItem).hasClass(toggleClass) # Add filter for parent
+    $.fn.firstChild          = -> $(this).parent().is($firstListItem) # Add filter for parent
+
+#    $.fn.lastChild           = -> $(this).parent().is($lastListItem) # Add filter for parent
+    $.fn.lastChild           = -> $(this).closest($li).is($lastListItem)
+
+    $.fn.lastItem            = -> $(this).parent().is($veryLastListItem) # Add filter for parent
+
+    # Click actions
+    $.fn.toggleDrawer        = -> $(this).click()
+    $.fn.closeRootDrawer     = -> $(this).closest($rootListItem).find($a).first().click()
+    $.fn.closeParentDrawer   = -> $(this).closest($drawer).prevAll().filter($a).click()
+
+    # Focus actions
+    $.fn.focusNextRootDrawer = -> $(this).closest($rootListItem).nextAll().filter($listItem).find($a).first().focus() # Add filter for next
+#    $.fn.focusNextDrawer     = -> $(this).closest($toggledListItem).nextAll().filter($listItem).first().find($a).first().focus()
+    $.fn.focusParentDrawer   = -> $(this).closest($drawer).prevAll().filter($a).first().focus()
+    $.fn.focusNextItem       = -> $(this).closest($listItem).nextAll().filter($listItem).first().find($a).first().focus()
+    $.fn.focusPreviousItem   = -> $(this).closest($listItem).prevAll().filter($listItem).first().find($a).first().focus()
+    $.fn.focusDrawerItem     = -> $(this).nextAll().filter($drawer).first().find($listItem).first().find($a).first().focus()
+    $.fn.focusDrawerItemUp   = -> $(this).closest($listItem).prevAll().filter($toggledListItem).first().find($listItem).last().find($a).first().focus() # This name sucks
+
+    # Bind arrow keys
+    $a.keydown (event) ->
+      $this = $(this)
+
+      # Left
+      if event.keyCode is 37
+        event.preventDefault()
+        if $this.drawerOpened()
+          $this.toggleDrawer()
+        else                            # From here down are the same
+          $this.focusPreviousItem()
+          if $this.closest($listItem).prevAll().filter($listItem).hasClass(toggleClass) # These need to be in logic functions
+            $this.focusDrawerItemUp()
+
+      # Up
+      if event.keyCode is 38
+        event.preventDefault()
+        if $this.firstChild()
+          $this.focusParentDrawer()
+        else                            # From here down are the same
+          $this.focusPreviousItem()
+          if $this.closest($listItem).prevAll().filter($listItem).first().hasClass(toggleClass) # These need to be in logic functions
+            $this.focusDrawerItemUp()
+
+          #if when there's a previous drawer open, focus the last item in that drawer
+            #log('yes')
+
+      # Right
+      if event.keyCode is 39
+        event.preventDefault()
+        if $this.drawerExists()
+          if $this.drawerOpened()
+            $this.focusDrawerItem()
+          else
+            $this.toggleDrawer()
+        else
+          if $this.lastChild()
+            if $this.lastItem() # you're not working, i dont' think
+              $this.closeRootDrawer()
+              $this.focusNextRootDrawer()
+            else
+              $this.closeParentDrawer().focusNextItem()
+          else
+            $this.focusNextItem()
+
+      # Down
+      if event.keyCode is 40
+        event.preventDefault()
+        if $this.lastChild()
+          if $this.has($veryLastListItem) # not sure what logic is best
+            $this.focusDrawerItem()
+          else
+            $this.focusNextDrawer()
+        else
+          if $this.drawerOpened()
+            $this.focusDrawerItem()
+          else
+            $this.focusNextItem()
 
     # Allow chaining
     return this


### PR DESCRIPTION
There are a lot of things still broken. I want this to be a very tolerant drop-down menu, meaning if there are elements wrapped around list-items, anchors or lists or if there is a div or span between list-items, it will still work just fine. This pull request won't be ready to merge until all of the issues are fixed. I'll add more to this list as I find them. (for now)

Issues I know of:
1. ~~When pressing down and reaching the end of a list the focus should move to the next drawer.~~
2. When pressing up and the previous drawer is open the focus should move to the last visible list-item in that drawer.
3. ~~`parent()` needs to be replaced with `closest().first( [filter] )` (when able) to ensure elements can be wrapped.~~
4. Compress duplicate logic into functions.
5. Line 179 - I'm not sure if this logic is reliable or the best way to determine the last list.
6. When reaching the last item of the last drawer, the focus should warp to the next root drawer.
